### PR TITLE
refactor: stock api 리턴 값 필요없는 필드 제거

### DIFF
--- a/backend/routes/editor/stock.js
+++ b/backend/routes/editor/stock.js
@@ -23,7 +23,18 @@ router.get("/", async (req, res) => {
     });
     console.log("성공!");
 
-    res.status(200).json(apiResp);
+    res.status(200).json({
+      stockTitle: apiResp.output1.hts_kor_isnm,
+      data: apiResp.output2.map((ele) => {
+        return {
+          open: ele.stck_oprc,
+          high: ele.stck_hgpr,
+          low: ele.stck_lwpr,
+          close: ele.stck_clpr,
+          date: ele.stck_bsop_date,
+        };
+      }),
+    });
   } catch (error) {
     console.error(error);
     res.status(500).send("Error fetching data");


### PR DESCRIPTION
### PR 타입
- [] 기능 추가
- [X] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
yapyap -> main

### 변경 사항
에디터에서 차트를 그릴 때 사용하는 stock api가 너무 쓸모없는 정보도 같이 리턴해주고 있어서 가독성이 떨어져 차트를 그릴 때 필요한 필드만을 리턴하도록 수정했습니다.

