### PR TITLE
post 리스트 가져오는 API

### DIFF
--- a/backend/model/post.js
+++ b/backend/model/post.js
@@ -36,6 +36,12 @@ const postSchema = new mongoose.Schema(
   {
     timestamps: true,
     versionKey: false,
+    toJSON: {
+      virtuals: true,
+    },
+    toObject: {
+      virtuals: true,
+    },
   }
 );
 

--- a/backend/model/post.js
+++ b/backend/model/post.js
@@ -6,6 +6,15 @@ const blockSchema = new mongoose.Schema({
   blocks: { type: [Object] },
 });
 
+const previewSchema = new mongoose.Schema({
+  text: { type: String, default: "Typer" },
+  img: {
+    type: String,
+    default:
+      "https://i.guim.co.uk/img/media/8c7f4fe66d305fb86fc3246dd47a9c06d216f7ec/0_139_1268_761/master/1268.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=f27fa05d2f7629655beafeb9248c7647",
+  },
+});
+
 const postSchema = new mongoose.Schema(
   {
     userId: {
@@ -22,6 +31,7 @@ const postSchema = new mongoose.Schema(
       ref: "user",
       default: [],
     },
+    preview: { type: previewSchema, require: true },
   },
   {
     timestamps: true,

--- a/backend/model/post.js
+++ b/backend/model/post.js
@@ -8,16 +8,20 @@ const blockSchema = new mongoose.Schema({
 
 const postSchema = new mongoose.Schema(
   {
-    userId: { type: String, required: true },
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+      ref: "user",
+    },
     title: { type: Object, required: true },
     content: { type: blockSchema, required: true },
     public: { type: Boolean, required: true },
-    
-    scrapingUsers : {
+
+    scrapingUsers: {
       type: [mongoose.Schema.Types.ObjectId],
       ref: "user",
       default: [],
-    }
+    },
   },
   {
     timestamps: true,

--- a/backend/model/user.js
+++ b/backend/model/user.js
@@ -13,10 +13,6 @@ const userSchema = new mongoose.Schema(
     comment: { type: String, default: null },
     profile: { type: String, required: true },
     token: kakaoTokenSchema,
-    writedPost: {
-      type: [mongoose.Schema.Types.ObjectId],
-      ref: "post",
-    },
     scrappedPosts: {
       type: [mongoose.Schema.Types.ObjectId],
       ref: "post",
@@ -25,8 +21,20 @@ const userSchema = new mongoose.Schema(
   },
   {
     timestamps: true,
+    toJSON: {
+      virtuals: true,
+    },
+    toObject: {
+      virtuals: true,
+    },
   }
 );
+
+userSchema.virtual("posts", {
+  ref: "post",
+  localField: "_id",
+  foreignField: "userId",
+});
 
 userSchema.statics.enroll = async function (
   userId,

--- a/backend/model/user.js
+++ b/backend/model/user.js
@@ -13,12 +13,15 @@ const userSchema = new mongoose.Schema(
     comment: { type: String, default: null },
     profile: { type: String, required: true },
     token: kakaoTokenSchema,
-
+    writedPost: {
+      type: [mongoose.Schema.Types.ObjectId],
+      ref: "post",
+    },
     scrappedPosts: {
       type: [mongoose.Schema.Types.ObjectId],
       ref: "post",
       default: [],
-    }
+    },
   },
   {
     timestamps: true,

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -71,7 +71,7 @@ router.post("/", async (req, res) => {
         httpOnly: true,
         maxAge: 3600000 * 2,
         secure: false,
-        sameSite: "None",
+        samesite: "None",
       });
 
       res.status(201).json({
@@ -100,7 +100,7 @@ router.post("/", async (req, res) => {
       res.cookie("authToken", jwtToken, {
         httpOnly: true,
         maxAge: 3600000 * 2,
-        sameSite: "None",
+        samesite: "None",
       });
 
       res.status(200).json({

--- a/backend/routes/post.js
+++ b/backend/routes/post.js
@@ -2,6 +2,7 @@ var express = require("express");
 var router = express.Router();
 const Post = require("../model/post");
 const User = require("../model/user");
+const Follower = require("../model/follower");
 const { ObjectId } = require("mongodb");
 const { authenticateJWT } = require("../utils/authenticateJWT");
 const mongoose = require("mongoose");
@@ -263,6 +264,13 @@ router.get("/list", authenticateJWT, async (req, res) => {
     const query = {};
     if (req.query.type) {
       query.type = req.query.type;
+      if (query.type === "follow") {
+        const follow = await Follower.findById(req.user._id);
+        const followList = follow.following_userId;
+        console.log(followList);
+
+        query.userId;
+      }
     }
 
     const result = await Post.find(query)

--- a/backend/routes/post.js
+++ b/backend/routes/post.js
@@ -19,14 +19,26 @@ router.post("/", authenticateJWT, async (req, res) => {
     return;
   }
 
-  console.log(body.content);
-  console.log(typeof body.content);
+  const prevText = body.content.blocks.reduce((acc, cur, idx) => {
+    if (cur.type === "paragraph") {
+      return acc + " " + cur.data.text;
+    }
+    return acc;
+  }, "");
+
+  const prevImg = body.content.blocks.find((item) => {
+    item.type === "img";
+  });
 
   Post.create({
     userId: user._id,
     title: body.title,
     content: body.content,
     public: body.public,
+    preview: {
+      text: prevText,
+      img: prevImg?.data.url,
+    },
   })
     .then((data) => {
       res.status(201).json(data);

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -43,6 +43,7 @@ router.get("/info/:_id", async (req, res, next) => {
           preview: ele.preview,
           createdAt: ele.createdAt,
           public: ele.public,
+          scrapingCount: ele.scrapingUsers.length,
         };
       }),
     });

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -36,7 +36,15 @@ router.get("/info/:_id", async (req, res, next) => {
       nickname: userData.nickname,
       comment: userData.comment,
       profile: userData.profile,
-      writerdPost: userData.posts,
+      writerdPost: userData.posts.map((ele, idx) => {
+        return {
+          title: ele.title,
+          _id: ele._id,
+          preview: ele.preview,
+          createdAt: ele.createdAt,
+          public: ele.public,
+        };
+      }),
     });
   } catch (error) {
     console.error("마이페이지에 유저 정보를 띄우기 위한 api 에러: ", error);

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -24,7 +24,7 @@ router.get("/", authenticateJWT, async (req, res, next) => {
 router.get("/info/:_id", async (req, res, next) => {
   try {
     const userId = req.params._id;
-    const userData = await User.findById(userId);
+    const userData = await User.findById(userId).populate("posts");
 
     if (!userData) {
       res.status(404).json({ errorMessage: "유저 조회 ㄴㄴ" });
@@ -36,6 +36,7 @@ router.get("/info/:_id", async (req, res, next) => {
       nickname: userData.nickname,
       comment: userData.comment,
       profile: userData.profile,
+      writerdPost: userData.posts,
     });
   } catch (error) {
     console.error("마이페이지에 유저 정보를 띄우기 위한 api 에러: ", error);


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [X] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
yapyap-postList => main

### 변경 사항
글 목록을 가져오는 API들을 작성했습니다.

1. post 스키마에 preview 필드 추가
post는 list 형태로 불러올 때 모든 필드를 전부 가져올 필요가 없습니다. 특히 post에 포함된 content.block같은 경우 포스트에 따라서 매우 길 가능성이 있기 때문에 미리보기를 위한 preview 필드를 만들었습니다.
preview는 포스트 내 paragraph블록의 data를 연결한 text, 처음으로 삽입된 img 블록의 url을 담는 img 필드를 가집니다.
만약 paragraph, img 블록이 없는 경우 default value가 적용됩니다.

preview는 post가 작성될 당시 자동으로 생성됩니다.

2. user/info 리턴 값에 writedPost 필드 추가
마이페이지에서 본인이 작성한 글을 보여주기 위해서 user/info 리턴 값에 writedPost를 추가했습니다.
writedPost는 title, id(post의 id), preview, createdAt, public, scrapingCount(해당 글을 스크랩한 유저 수)로 구성됩니다.

현재는 본인이 아닌 다른 사람의 마이페이지에 접근할 때 public이 아닌 post들도 전부 다 보여지게 되어있지만 추후에 현재 요청하는 유저의 정보가 아닌 경우 public이 아닌 post는 포함시키지 않도록 수정하겠습니다.

3. post/list API추가
메인화면 등 에서 사용하게 될 post List를 가져오는 api 입니다.
쿼리 파라미터로 옵션을 받아 다양한 검색 기능을 제공합니다.
기본적으로 10개 씩 pagination이 적용되어 있습니다. page 파라미터에 조회하고자 하는 페이지를 넣으면 됩니다.
만약 본인이 팔로우 한 유저의 post만을 조회하고 싶으면 type=follow를 추가하면 됩니다.
쿠키에 담긴 세션 정보를 이용해 해당 유저가 팔로우 하고 있는 유저가 작성한 글 만을 조회합니다.

post는 작성일자 순으로 정렬되어있습니다.


### 테스트 결과
![image](https://github.com/Typerproject/Backend/assets/99272057/54dadf52-a09b-46cc-9663-b8c1378ece66)
user/info 조회
![image](https://github.com/Typerproject/Backend/assets/99272057/739a6a51-93d8-4c47-afc4-24c63f40ee0e)
조회 결과


![image](https://github.com/Typerproject/Backend/assets/99272057/b2462257-2994-4f50-af32-fd655e56b8e7)
post/list 기본 조회

![image](https://github.com/Typerproject/Backend/assets/99272057/369f7eaf-4426-473f-8f09-dfaf76e3d8a0)
쿠키가 있는 채로 type=follow 조회