### PR TITLE
'NoSQL은 신이 아니였다.' Post, User 사이 ScrappedPost 리스트 제거 로직 추가

### DIFF
--- a/backend/routes/post.js
+++ b/backend/routes/post.js
@@ -166,13 +166,26 @@ router.post("/", authenticateJWT, async (req, res) => {
     return;
   }
 
-  const prevText = body.content.blocks.reduce((acc, cur, idx) => {
-    if (cur.type === "paragraph") {
-      let dom = parser.parse(cur.data.text);
-      return acc + " " + dom.textContent;
+  let prevText = "";
+
+  for (const block of body.content.blocks) {
+    if (block.type === "paragraph") {
+      let dom = parser.parse(block.data.text);
+      prevText += " " + dom.textContent;
     }
-    return acc;
-  }, "");
+
+    if (prevText.length >= 100) {
+      break;
+    }
+  }
+
+  // const prevText = body.content.blocks.reduce((acc, cur, idx) => {
+  //   if (cur.type === "paragraph") {
+  //     let dom = parser.parse(cur.data.text);
+  //     return acc + " " + dom.textContent;
+  //   }
+  //   return acc;
+  // }, "");
 
   const prevImg = body.content.blocks.find((item) => {
     return item.type === "image";
@@ -585,13 +598,18 @@ router.patch("/:postId", authenticateJWT, async (req, res) => {
   // block이 blockSchema 형식에 맞는지 check.. 해야 할까?
 
   // preview update 해야 함
-  const prevText = body.content.blocks.reduce((acc, cur, idx) => {
-    if (cur.type === "paragraph") {
-      let dom = parser.parse(cur.data.text);
-      return acc + " " + dom.textContent;
+  let prevText = "";
+
+  for (const block of body.content.blocks) {
+    if (block.type === "paragraph") {
+      let dom = parser.parse(block.data.text);
+      prevText += " " + dom.textContent;
     }
-    return acc;
-  }, "");
+
+    if (prevText.length >= 100) {
+      break;
+    }
+  }
 
   const prevImg = body.content.blocks.find((item) => item.type === "image");
 

--- a/backend/routes/post.js
+++ b/backend/routes/post.js
@@ -179,14 +179,6 @@ router.post("/", authenticateJWT, async (req, res) => {
     }
   }
 
-  // const prevText = body.content.blocks.reduce((acc, cur, idx) => {
-  //   if (cur.type === "paragraph") {
-  //     let dom = parser.parse(cur.data.text);
-  //     return acc + " " + dom.textContent;
-  //   }
-  //   return acc;
-  // }, "");
-
   const prevImg = body.content.blocks.find((item) => {
     return item.type === "image";
   });
@@ -277,25 +269,43 @@ router.delete("/:postId", authenticateJWT, async (req, res) => {
         userId.toString
       }   포스트 유저: ${targetPost.userId.toString()}`,
     });
-  }
-
-  const result = await Post.deleteOne({ _id: postId });
-
-  if (result.deletedCount === 1) {
-    await Comment.deleteMany({ postId: postId });
-    await Reply.deleteMany({ postId: postId });
-
-    res.json({
-      msg: "포스트 삭제 완료",
-      body: result,
-    });
     return;
   }
 
-  res.status(500).json({
-    msg: "포스트 삭제 실패",
-    body: result,
-  });
+  const session = await mongoose.startSession();
+
+  try {
+    session.startTransaction();
+
+    const updateRes = await User.updateMany(
+      { _id: { $in: targetPost.scrapingUsers } },
+      { $pull: { scrappedPosts: { $in: [targetPost._id] } } }
+    );
+
+    console.log(updateRes);
+
+    const result = await Post.deleteOne({ _id: postId });
+
+    if (result.deletedCount === 1) {
+      await Comment.deleteMany({ postId: postId });
+      await Reply.deleteMany({ postId: postId });
+
+      await session.commitTransaction(); // 성공 시 커밋
+
+      res.json({
+        msg: "포스트 삭제 완료",
+        body: result,
+      });
+      return;
+    }
+  } catch (err) {
+    await session.abortTransaction();
+    res.status(500).json({
+      msg: "포스트 삭제 실패",
+      body: result,
+      reason: err,
+    });
+  }
 });
 
 router.patch("/scrap", authenticateJWT, async (req, res) => {
@@ -472,29 +482,6 @@ router.get("/scrap/list", authenticateJWT, async (req, res) => {
   const perPage = 10;
   const currentPage = req.query.page || 1;
 
-  // { <arrayField>: { $slice: [ <number>, <number> ] } }
-
-  // 옛날 코드
-  // const scrapList = await User.findOne(
-  //   {
-  //     _id: userId,
-  //   },
-  //   {
-  //     // 배열 형태인 필드 읽는 범위 조절
-  //     scrappedPosts: { $slice: [(currentPage - 1) * perPage, perPage] },
-  //   }
-  // )
-  //   .populate({
-  //     path: "scrappedPosts",
-  //     select: "_id userId title updatedAt preview scrapingUsers commentCount", //commentCount일단 추가
-  //     populate: {
-  //       path: "userId",
-  //       select: "_id nickname profile",
-  //     },
-  //   })
-  //   .lean();
-
-  //aggregate로 저장된 배열 뒤집어서 가져오기
   const scrapList2 = await User.aggregate([
     {
       $match: {
@@ -513,23 +500,7 @@ router.get("/scrap/list", authenticateJWT, async (req, res) => {
         },
       },
     },
-    // {
-    //   $lookup: {
-    //     from: "posts",
-    //     localField: "scrappedPosts",
-    //     foreignField: "_id",
-    //     as: "sp2",
-    //   },
-    // },
-    // { "$unwind": "$sp2" },
-    // pipe
   ]);
-  // .lookup({
-  //   from: "posts",
-  //   localField: "scrappedPosts",
-  //   foreignField: "_id",
-  //   as: "sp2",
-  // });
 
   if (scrapList2[0].scrappedPosts.length === 0) {
     return res.status(200).json({


### PR DESCRIPTION
### PR 타입
- [] 기능 추가
- [X] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
yapyap->main

### 변경 사항
NoSQL인 MongoDB는 연관관계를 직접적으로 지원하지 않습니다.(Constarint 가 없음) 따라서 한 스키마가 다른 스키마를 참조하고 있더라도 Cascade 등의 작업이 불가능합니다.
User와 Post는 스크랩 여부라는 관계를 가지고 있어 각 스키마에 Array로 스크랩한 포스트의 ID, 스크랩한 유저의 ID를 보관하고 있었지만 Post가 삭제되는 경우 User의 ScrappedPosts Array에 존재하지 않는 Post의 ID가 남아있게 되었습니다.
한 유저가 스크랩한 Post를 가져오는 API에서 만약 해당 ID의 Post가 존재하지 않으면 populate의 결과가 null로 나타나 큰 문제가 없었지만 Pagenation을 하는 과정에서 문제가 발생했습니다.

따라서 한 post가 삭제되는 경우 해당 Post를 스크랩한 모든 유저의 스카마의 ScrappedPost array에서 해당 Post의 ID를 제거합니다. 한번의 쿼리?로 수행되기 때문에 큰 문제는 없지않을까 싶습니다.
