### PR TITLE
feat: 포스트 삭제 시 S3에서 포함 이미지 삭제 추가

### DIFF
--- a/backend/routes/post.js
+++ b/backend/routes/post.js
@@ -20,7 +20,15 @@ AWS.config.update({
 
 const s3 = new AWS.S3();
 
-const decodeImg = async (base64) => {
+const decodeImg = async (url) => {
+  const array = url.split(",");
+
+  if (array.length < 2) {
+    return url;
+  }
+
+  const base64 = array[1];
+
   const buffer = Buffer.from(base64, "base64");
   const fileName = `${uuidv4()}.jpg`;
 
@@ -209,8 +217,7 @@ router.post("/", authenticateJWT, async (req, res) => {
     }
 
     if (block.type === "image") {
-      const url = await decodeImg(block.data.url.split(",")[1]);
-      console.log(url);
+      const url = await decodeImg(block.data.url);
       block.data.url = url;
     }
   }
@@ -326,6 +333,27 @@ router.delete("/:postId", authenticateJWT, async (req, res) => {
       await Reply.deleteMany({ postId: postId });
 
       await session.commitTransaction(); // 성공 시 커밋
+
+      var params = {
+        Bucket: "typer-static",
+        Delete: {
+          Objects: targetPost.content.blocks.map((block) => {
+            if (block.type === "image") {
+              console.log(block.data.url);
+              const array = block.data.url.split("/");
+              console.log(array[array.length - 1]);
+              return {
+                Key: array[array.length - 1],
+              };
+            }
+          }),
+          Quiet: false,
+        },
+      };
+      s3.deleteObjects(params, function (err, data) {
+        if (err) console.log(err, err.stack); // an error occurred
+        else console.log(data); // successful response
+      });
 
       res.json({
         msg: "포스트 삭제 완료",
@@ -610,10 +638,15 @@ router.patch("/:postId", authenticateJWT, async (req, res) => {
     if (block.type === "paragraph") {
       let dom = parser.parse(block.data.text);
       prevText += " " + dom.textContent;
+
+      if (prevText.length >= 100) {
+        continue;
+      }
     }
 
-    if (prevText.length >= 100) {
-      break;
+    if (block.type === "image") {
+      const url = await decodeImg(block.data.url);
+      block.data.url = url;
     }
   }
 


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
yapyap -> main


### 변경 사항
포스트가 삭제되는 경우 S3에서는 이미지가 그대로 존재해 리소스가 낭비되었습니다.
앞으로 포스트가 삭제될 때 포함되어있던 이미지들을 S3에서 삭제합니다.